### PR TITLE
Returns a generic "Registration failed" message to the client 

### DIFF
--- a/app/api/auth/register/route.js
+++ b/app/api/auth/register/route.js
@@ -57,12 +57,12 @@ export async function POST(request) {
             { message: "User registered successfully", user: { email: user.email, name: user.name, role: user.role } },
             { status: 201 }
         );
-    }catch (error) {
-    console.error("REGISTER ERROR FULL:", error);
-    return NextResponse.json(
-        { error: error.message, stack: error.stack },
-        { status: 500 }
-    );
-}
+    } catch (error) {
+        console.error("REGISTER ERROR FULL:", error);
+        return NextResponse.json(
+            { error: "Registration failed" },
+            { status: 500 }
+        );
+    }
 
 }


### PR DESCRIPTION
The catch block now:

✅ Returns a generic "Registration failed" message to the client
✅ Still logs the full error server-side via console.error on line 61
