### PR TITLE
fix: Remove duplicate authorized callback causing role-based routing …

### DIFF
--- a/lib/auth.config.js
+++ b/lib/auth.config.js
@@ -4,49 +4,5 @@ export const authConfig = {
     pages: {
         signIn: "/login",
     },
-    callbacks: {
-        authorized({ auth, request: { nextUrl } }) {
-            const isLoggedIn = !!auth?.user;
-            const { pathname } = nextUrl;
-
-            const publicRoutes = ["/", "/login", "/register", "/events", "/verify", "/profile"];
-            const isPublicRoute = publicRoutes.includes(pathname);
-
-            if (isPublicRoute) return true;
-
-            // For /profile, check if user is logged in
-            if (pathname === "/profile") {
-                if (!isLoggedIn) return false;
-                return true;
-            }
-
-            if (!isLoggedIn) return false;
-
-            const dashboardRoutes = {
-                "/admin": "admin",
-                "/organizer": "organizer",
-                "/judge": "judge",
-                "/mentor": "mentor",
-                "/participant": "participant",
-            };
-
-            const userRole = auth.user.role || "participant";
-
-            for (const [route, requiredRole] of Object.entries(dashboardRoutes)) {
-                if (pathname.startsWith(route)) {
-                    if (userRole !== requiredRole) {
-                        const targetPath = `/${userRole}`;
-                        if (pathname === targetPath) return true;
-
-                        const redirectUrl = new URL(targetPath, nextUrl);
-                        return Response.redirect(redirectUrl);
-                    }
-                    return true;
-                }
-            }
-
-            return true;
-        },
-    },
     providers: [],
 };


### PR DESCRIPTION
…to fail

The auth.config.js had its own authorized callback that was overriding the role-based routing logic in auth.js. This caused all users to be redirected to /participant regardless of their actual role.

The fix removes the duplicate callback from auth.config.js, allowing the proper role-based authorization in auth.js to work correctly.

Also added NEXTAUTH_SECRET to .env for proper session handling.