### PR TITLE
fix: add missing keyboard navigation and focus trap modules

### DIFF
--- a/components/common/keyboardNavigation.js
+++ b/components/common/keyboardNavigation.js
@@ -1,0 +1,101 @@
+/**
+ * Handles keyboard navigation for tablist elements (role="tablist")
+ * Navigates between tabs using arrow keys and activates on Enter/Space
+ * 
+ * @param {React.KeyboardEvent} event - The keyboard event
+ * @param {string} [selector] - Optional selector for tab elements (default: '[role="tab"]')
+ */
+export function handleTabListKeyDown(event, selector = '[role="tab"]') {
+  const { key, target } = event;
+  const parent = target.closest('[role="tablist"]');
+  if (!parent) return;
+
+  const tabs = Array.from(parent.querySelectorAll(selector));
+  const currentIndex = tabs.indexOf(target);
+
+  if (currentIndex === -1) return;
+
+  let newIndex = currentIndex;
+
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      event.preventDefault();
+      newIndex = (currentIndex + 1) % tabs.length;
+      break;
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      event.preventDefault();
+      newIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      break;
+    case 'Home':
+      event.preventDefault();
+      newIndex = 0;
+      break;
+    case 'End':
+      event.preventDefault();
+      newIndex = tabs.length - 1;
+      break;
+    case 'Enter':
+    case ' ':
+      event.preventDefault();
+      target.click();
+      return;
+    default:
+      return;
+  }
+
+  tabs[newIndex]?.focus();
+}
+
+/**
+ * Handles keyboard navigation for listbox elements (role="listbox")
+ * Navigates between options using arrow keys and selects on Enter/Space
+ * 
+ * @param {React.KeyboardEvent} event - The keyboard event
+ * @param {string} selector - Selector for selectable elements (e.g., '[role="option"]', 'button:not([disabled])')
+ */
+export function handleArrowListKeyDown(event, selector) {
+  const { key, target } = event;
+  const parent = target.closest('[role="listbox"]');
+  if (!parent) return;
+
+  const options = Array.from(parent.querySelectorAll(selector));
+  const currentIndex = options.indexOf(target);
+
+  if (currentIndex === -1) return;
+
+  let newIndex = currentIndex;
+
+  switch (key) {
+    case 'ArrowDown':
+      event.preventDefault();
+      newIndex = (currentIndex + 1) % options.length;
+      break;
+    case 'ArrowUp':
+      event.preventDefault();
+      newIndex = (currentIndex - 1 + options.length) % options.length;
+      break;
+    case 'Home':
+      event.preventDefault();
+      newIndex = 0;
+      break;
+    case 'End':
+      event.preventDefault();
+      newIndex = options.length - 1;
+      break;
+    case 'Enter':
+    case ' ':
+      event.preventDefault();
+      target.click();
+      return;
+    case 'Escape':
+    case 'Tab':
+      // Let default behavior handle these
+      return;
+    default:
+      return;
+  }
+
+  options[newIndex]?.focus();
+}

--- a/components/common/useFocusTrap.js
+++ b/components/common/useFocusTrap.js
@@ -1,0 +1,101 @@
+import { useEffect, useCallback } from 'react';
+
+/**
+ * Custom hook for trapping focus within a container element
+ * Useful for modals and dialogs to keep focus within the element
+ * 
+ * @param {Object} options - Configuration options
+ * @param {boolean} options.isOpen - Whether the modal/dialog is open
+ * @param {React.RefObject} options.containerRef - Reference to the container element
+ * @param {Function} options.onClose - Callback function to close the modal
+ * @param {React.RefObject} [options.initialFocusRef] - Reference to element for initial focus
+ * @param {React.RefObject} [options.triggerRef] - Reference to the trigger button
+ */
+export default function useFocusTrap({
+  isOpen,
+  containerRef,
+  onClose,
+  initialFocusRef,
+  triggerRef,
+}) {
+  const handleKeyDown = useCallback((event) => {
+    if (event.key !== 'Escape') return;
+
+    // Handle Escape key
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      if (onClose) {
+        onClose();
+      }
+      // Return focus to trigger when closed
+      if (triggerRef?.current) {
+        triggerRef.current.focus();
+      }
+    }
+  }, [onClose, triggerRef]);
+
+  const handleFocusIn = useCallback((event) => {
+    if (!isOpen || !containerRef?.current) return;
+
+    const focusableElements = containerRef.current.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    // Check if focus is outside the container
+    if (!containerRef.current.contains(event.target)) {
+      // Prevent focus from leaving
+      if (firstElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    }
+  }, [isOpen, containerRef]);
+
+  useEffect(() => {
+    if (!isOpen || !containerRef?.current) return;
+
+    // Add event listeners
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('focusin', handleFocusIn);
+
+    // Focus initial element
+    if (initialFocusRef?.current) {
+      setTimeout(() => {
+        initialFocusRef.current?.focus();
+      }, 0);
+    } else {
+      // Fallback: focus first focusable element
+      const focusableElements = containerRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableElements[0]) {
+        setTimeout(() => {
+          focusableElements[0].focus();
+        }, 0);
+      }
+    }
+
+    // Store previous active element to restore later
+    const previousActiveElement = document.activeElement;
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('focusin', handleFocusIn);
+      
+      // Restore focus to trigger when modal closes
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        // Only restore if the element is still in the document
+        if (previousActiveElement.isConnected) {
+          previousActiveElement.focus();
+        }
+      }
+    };
+  }, [isOpen, containerRef, handleKeyDown, handleFocusIn, initialFocusRef]);
+
+  return {
+    // No return value needed - the hook manages focus internally
+  };
+}

--- a/components/ui/form/Input.tsx
+++ b/components/ui/form/Input.tsx
@@ -1,12 +1,13 @@
-import React from "react";
+import React, { forwardRef } from "react";
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   error?: string;
 };
 
-export default function Input({ error, className, ...props }: InputProps) {
+export default forwardRef<HTMLInputElement, InputProps>(function Input({ error, className, ...props }, ref) {
   return (
     <input
+      ref={ref}
       {...props}
       className={[
         "w-full px-3 py-2 rounded-lg border",
@@ -20,4 +21,4 @@ export default function Input({ error, className, ...props }: InputProps) {
       ].join(" ")}
     />
   );
-}
+});


### PR DESCRIPTION
- Add components/common/keyboardNavigation.js with handleTabListKeyDown and handleArrowListKeyDown functions
- Add components/common/useFocusTrap.js custom hook for modal focus trapping
- Fix components/ui/form/Input.tsx to properly forward refs using React.forwardRef

These changes fix the build error:
Module not found: Can't resolve '@/components/common/keyboardNavigation'