### PR TITLE
fix: add missing rate-limit import in teams API

### DIFF
--- a/app/api/teams/route.js
+++ b/app/api/teams/route.js
@@ -5,6 +5,9 @@ import User from "@/models/User";
 import Event from "@/models/Event";
 import mongoose from "mongoose";
 import { auth } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
+
+const limiter = rateLimit({ interval: 60000 });
 
 // GET all teams
 export async function GET(request) {


### PR DESCRIPTION
- Import rateLimit from @/lib/rate-limit
- Create limiter instance for rate limiting
- Fixes 500 Internal Server Error when creating a team