### PR TITLE
feat: Add tooltips to dashboard filter icons

### DIFF
--- a/app/(dashboard)/admin/AdminDashboardClient.js
+++ b/app/(dashboard)/admin/AdminDashboardClient.js
@@ -3,6 +3,7 @@
 import React, { useRef, useState, useEffect } from "react";
 import useFocusTrap from "@/components/common/useFocusTrap";
 import { handleTabListKeyDown } from "@/components/common/keyboardNavigation";
+import Tooltip from "@/components/common/Tooltip";
 
 // Icons as simple SVG components
 const Icons = {
@@ -661,7 +662,9 @@ export default function AdminDashboardClient({ user }) {
                   className="w-full bg-slate-900/50 border border-slate-600/50 rounded-lg pl-10 pr-4 py-2.5 text-white placeholder-slate-500 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 transition-colors"
                 />
                 <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">
-                  <Icons.Search />
+                  <Tooltip content="Search Users" position="right">
+                    <Icons.Search />
+                  </Tooltip>
                 </div>
               </div>
               <select
@@ -723,20 +726,22 @@ export default function AdminDashboardClient({ user }) {
                         </td>
                         <td className="py-4 px-6 text-right">
                           <div className="flex items-center justify-end gap-2">
-                            <button
-                              onClick={() => handleEditUser(userItem)}
-                              className="p-2 text-slate-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg transition-colors"
-                              title="Edit"
-                            >
-                              <Icons.Edit />
-                            </button>
-                            <button
-                              onClick={() => handleDeleteUser(userItem._id)}
-                              className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
-                              title="Delete"
-                            >
-                              <Icons.Trash />
-                            </button>
+                            <Tooltip content="Edit User">
+                              <button
+                                onClick={() => handleEditUser(userItem)}
+                                className="p-2 text-slate-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg transition-colors"
+                              >
+                                <Icons.Edit />
+                              </button>
+                            </Tooltip>
+                            <Tooltip content="Delete User">
+                              <button
+                                onClick={() => handleDeleteUser(userItem._id)}
+                                className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                              >
+                                <Icons.Trash />
+                              </button>
+                            </Tooltip>
                           </div>
                         </td>
                       </tr>
@@ -975,20 +980,22 @@ export default function AdminDashboardClient({ user }) {
                         </td>
                         <td className="py-4 px-6 text-right">
                           <div className="flex items-center justify-end gap-2">
-                            <button
-                              onClick={() => handleEditEvent(event)}
-                              className="p-2 text-slate-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg transition-colors"
-                              title="Edit"
-                            >
-                              <Icons.Edit />
-                            </button>
-                            <button
-                              onClick={() => handleDeleteEvent(event._id)}
-                              className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
-                              title="Delete"
-                            >
-                              <Icons.Trash />
-                            </button>
+                            <Tooltip content="Edit Event">
+                              <button
+                                onClick={() => handleEditEvent(event)}
+                                className="p-2 text-slate-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg transition-colors"
+                              >
+                                <Icons.Edit />
+                              </button>
+                            </Tooltip>
+                            <Tooltip content="Delete Event">
+                              <button
+                                onClick={() => handleDeleteEvent(event._id)}
+                                className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                              >
+                                <Icons.Trash />
+                              </button>
+                            </Tooltip>
                           </div>
                         </td>
                       </tr>
@@ -1117,13 +1124,14 @@ export default function AdminDashboardClient({ user }) {
                         {ann.expiresAt && <span>Expires: {new Date(ann.expiresAt).toLocaleDateString()}</span>}
                       </div>
                     </div>
-                    <button
-                      onClick={() => handleDeleteAnnouncement(ann._id)}
-                      className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors ml-4"
-                      title="Deactivate"
-                    >
-                      <Icons.Trash />
-                    </button>
+                    <Tooltip content="Deactivate Announcement" position="left">
+                      <button
+                        onClick={() => handleDeleteAnnouncement(ann._id)}
+                        className="p-2 text-slate-400 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors ml-4"
+                      >
+                        <Icons.Trash />
+                      </button>
+                    </Tooltip>
                   </div>
                 ))
               )}

--- a/app/(dashboard)/mentor/page.js
+++ b/app/(dashboard)/mentor/page.js
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect } from "react";
 import { Users, FileText, Calendar, Clock, ChevronRight, ExternalLink, AlertCircle } from "lucide-react";
 import Link from "next/link";
+import Tooltip from "@/components/common/Tooltip";
 
 export default function MentorDashboard() {
     const [teams, setTeams] = useState([]);
@@ -170,7 +170,9 @@ export default function MentorDashboard() {
                                 <p className="text-2xl font-bold text-slate-900 mt-1">{stats.assignedTeams}</p>
                             </div>
                             <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
-                                <Users className="w-6 h-6 text-blue-600" />
+                                <Tooltip content="Teams assigned to you">
+                                    <Users className="w-6 h-6 text-blue-600" />
+                                </Tooltip>
                             </div>
                         </div>
                     </div>
@@ -182,7 +184,9 @@ export default function MentorDashboard() {
                                 <p className="text-2xl font-bold text-slate-900 mt-1">{stats.pendingSubmissions}</p>
                             </div>
                             <div className="w-12 h-12 bg-amber-100 rounded-lg flex items-center justify-center">
-                                <FileText className="w-6 h-6 text-amber-600" />
+                                <Tooltip content="Submissions awaiting your review">
+                                    <FileText className="w-6 h-6 text-amber-600" />
+                                </Tooltip>
                             </div>
                         </div>
                     </div>
@@ -194,7 +198,9 @@ export default function MentorDashboard() {
                                 <p className="text-2xl font-bold text-slate-900 mt-1">{stats.reviewedSubmissions}</p>
                             </div>
                             <div className="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center">
-                                <FileText className="w-6 h-6 text-emerald-600" />
+                                <Tooltip content="Submissions you have already reviewed">
+                                    <FileText className="w-6 h-6 text-emerald-600" />
+                                </Tooltip>
                             </div>
                         </div>
                     </div>

--- a/app/(dashboard)/organizer/page.tsx
+++ b/app/(dashboard)/organizer/page.tsx
@@ -16,6 +16,7 @@ import {
     BarChart,
     Gavel
 } from "lucide-react";
+import Tooltip from "@/components/common/Tooltip";
 import OrganizerJudgeManager from "@/components/dashboards/organizer/OrganizerJudgeManager";
 import EmptyState from "@/components/common/EmptyState";
 import { Analytics } from "@/lib/analytics";
@@ -153,7 +154,9 @@ export default function OrganizerDashboard() {
                         <div className="flex items-center justify-between mb-4">
                             <p className="text-sm font-medium text-slate-500">Total Events</p>
                             <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-                                <Calendar className="w-5 h-5 text-blue-600" />
+                                <Tooltip content="Track your hackathons">
+                                    <Calendar className="w-5 h-5 text-blue-600" />
+                                </Tooltip>
                             </div>
                         </div>
                         <p className="text-3xl font-bold text-slate-900">{events.length}</p>
@@ -163,7 +166,9 @@ export default function OrganizerDashboard() {
                         <div className="flex items-center justify-between mb-4">
                             <p className="text-sm font-medium text-slate-500">Participants</p>
                             <div className="w-10 h-10 bg-emerald-100 rounded-lg flex items-center justify-center">
-                                <Users className="w-5 h-5 text-emerald-600" />
+                                <Tooltip content="Total participants across events">
+                                    <Users className="w-5 h-5 text-emerald-600" />
+                                </Tooltip>
                             </div>
                         </div>
                         <p className="text-3xl font-bold text-slate-900">{stats.totalParticipants}</p>
@@ -173,7 +178,9 @@ export default function OrganizerDashboard() {
                         <div className="flex items-center justify-between mb-4">
                             <p className="text-sm font-medium text-slate-500">Upcoming</p>
                             <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
-                                <Clock className="w-5 h-5 text-amber-600" />
+                                <Tooltip content="Upcoming scheduled events">
+                                    <Clock className="w-5 h-5 text-amber-600" />
+                                </Tooltip>
                             </div>
                         </div>
                         <p className="text-3xl font-bold text-slate-900">
@@ -185,7 +192,9 @@ export default function OrganizerDashboard() {
                         <div className="flex items-center justify-between mb-4">
                             <p className="text-sm font-medium text-slate-500">Avg. Team Size</p>
                             <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-                                <BarChart className="w-5 h-5 text-purple-600" />
+                                <Tooltip content="Average members per team">
+                                    <BarChart className="w-5 h-5 text-purple-600" />
+                                </Tooltip>
                             </div>
                         </div>
                         <p className="text-3xl font-bold text-slate-900">{stats.avgTeamSize}</p>
@@ -229,15 +238,21 @@ export default function OrganizerDashboard() {
                                             <p className="text-sm text-slate-500 mb-4 line-clamp-1 max-w-2xl">{event.description}</p>
                                             <div className="flex items-center gap-6 text-sm text-slate-500">
                                                 <div className="flex items-center gap-2">
-                                                    <Calendar className="w-4 h-4 text-slate-400" />
+                                                    <Tooltip content="Event Start Date">
+                                                        <Calendar className="w-4 h-4 text-slate-400" />
+                                                    </Tooltip>
                                                     <span>{new Date(event.startDate).toLocaleDateString()}</span>
                                                 </div>
                                                 <div className="flex items-center gap-2">
-                                                    <Users className="w-4 h-4 text-slate-400" />
+                                                    <Tooltip content="Max Team Size">
+                                                        <Users className="w-4 h-4 text-slate-400" />
+                                                    </Tooltip>
                                                     <span>{event.maxTeamSize} max members</span>
                                                 </div>
                                                 <div className="flex items-center gap-2">
-                                                    <Clock className="w-4 h-4 text-slate-400" />
+                                                    <Tooltip content="Event Duration">
+                                                        <Clock className="w-4 h-4 text-slate-400" />
+                                                    </Tooltip>
                                                     <span>48h Duration</span>
                                                 </div>
                                             </div>

--- a/app/(dashboard)/participant/ParticipantDashboardClient.tsx
+++ b/app/(dashboard)/participant/ParticipantDashboardClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
 import { Bell, Users, Calendar, Clock, Copy, ExternalLink, Trophy, Plus, CheckCircle, XCircle, HandHelping } from "lucide-react";
 import Link from "next/link";
+import Tooltip from "@/components/common/Tooltip";
 
 interface User {
   id: string;
@@ -171,7 +171,9 @@ export default function ParticipantDashboardClient({ user }: Props) {
               <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700/50">
                   <div className="flex items-center justify-between mb-4">
                       <h2 className="text-xl font-bold flex items-center gap-2">
-                          <Users className="w-5 h-5 text-neon-cyan" />
+                          <Tooltip content="Teams you lead or have joined">
+                            <Users className="w-5 h-5 text-neon-cyan" />
+                          </Tooltip>
                           My Teams
                       </h2>
                       <Link href="/events" className="text-sm text-neon-cyan hover:text-white transition">
@@ -264,7 +266,9 @@ export default function ParticipantDashboardClient({ user }: Props) {
               {/* Submissions Section */}
               <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700/50">
                   <h2 className="text-xl font-bold flex items-center gap-2 mb-4">
-                      <Trophy className="w-5 h-5 text-neon-cyan" />
+                      <Tooltip content="Your overall hackathon progress">
+                        <Trophy className="w-5 h-5 text-neon-cyan" />
+                      </Tooltip>
                       My Submissions
                   </h2>
                   
@@ -322,7 +326,9 @@ export default function ParticipantDashboardClient({ user }: Props) {
               {/* Important Deadlines */}
               <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700/50">
                   <h2 className="text-xl font-bold flex items-center gap-2 mb-4">
-                      <Clock className="w-5 h-5 text-neon-cyan" />
+                      <Tooltip content="Important event deadlines">
+                        <Clock className="w-5 h-5 text-neon-cyan" />
+                      </Tooltip>
                       Important Deadlines
                   </h2>
                   
@@ -358,7 +364,9 @@ export default function ParticipantDashboardClient({ user }: Props) {
               {availableEvents.length > 0 && (
                   <div className="bg-slate-800 p-6 rounded-lg shadow-lg border border-slate-700/50">
                       <h2 className="text-xl font-bold flex items-center gap-2 mb-4">
-                          <Calendar className="w-5 h-5 text-neon-cyan" />
+                          <Tooltip content="Discover new hackathons">
+                            <Calendar className="w-5 h-5 text-neon-cyan" />
+                          </Tooltip>
                           Available Events
                       </h2>
                       

--- a/components/common/Tooltip.jsx
+++ b/components/common/Tooltip.jsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { cn } from "@/utils/cn";
+
+/**
+ * Tooltip Component
+ * 
+ * A lightweight, accessible tooltip component that appears on hover or focus.
+ * 
+ * @param {React.ReactNode} children - The trigger element for the tooltip.
+ * @param {string} content - The text content to display in the tooltip.
+ * @param {string} position - The position of the tooltip relative to the trigger (top, bottom, left, right).
+ * @param {string} className - Additional CSS classes for the tooltip container.
+ */
+const Tooltip = ({ 
+  children, 
+  content, 
+  position = "top", 
+  delay = 200,
+  className 
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [coords, setCoords] = useState({ x: 0, y: 0 });
+  const triggerRef = useRef(null);
+  const timeoutRef = useRef(null);
+
+  const showTooltip = () => {
+    timeoutRef.current = setTimeout(() => {
+      if (triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect();
+        let x = 0;
+        let y = 0;
+
+        switch (position) {
+          case "top":
+            x = rect.left + rect.width / 2;
+            y = rect.top;
+            break;
+          case "bottom":
+            x = rect.left + rect.width / 2;
+            y = rect.bottom;
+            break;
+          case "left":
+            x = rect.left;
+            y = rect.top + rect.height / 2;
+            break;
+          case "right":
+            x = rect.right;
+            y = rect.top + rect.height / 2;
+            break;
+          default:
+            x = rect.left + rect.width / 2;
+            y = rect.top;
+        }
+
+        setCoords({ x, y });
+        setIsVisible(true);
+      }
+    }, delay);
+  };
+
+  const hideTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClasses = {
+    top: "-translate-x-1/2 -translate-y-full mb-2",
+    bottom: "-translate-x-1/2 translate-y-0 mt-2",
+    left: "-translate-x-full -translate-y-1/2 mr-2",
+    right: "translate-x-0 -translate-y-1/2 ml-2",
+  };
+
+  const arrowClasses = {
+    top: "bottom-[-4px] left-1/2 -translate-x-1/2 border-t-slate-800 border-x-transparent border-t-4",
+    bottom: "top-[-4px] left-1/2 -translate-x-1/2 border-b-slate-800 border-x-transparent border-b-4",
+    left: "right-[-4px] top-1/2 -translate-y-1/2 border-l-slate-800 border-y-transparent border-l-4",
+    right: "left-[-4px] top-1/2 -translate-y-1/2 border-r-slate-800 border-y-transparent border-r-4",
+  };
+
+  return (
+    <div 
+      className={cn("relative inline-block", className)}
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
+      ref={triggerRef}
+    >
+      {children}
+      {isVisible && (
+        <div 
+          className={cn(
+            "fixed z-[9999] px-2 py-1 text-xs font-medium text-white bg-slate-800 rounded shadow-lg pointer-events-none whitespace-nowrap animate-in fade-in zoom-in duration-150",
+            positionClasses[position]
+          )}
+          style={{ 
+            left: `${coords.x}px`, 
+            top: `${coords.y}px` 
+          }}
+          role="tooltip"
+        >
+          {content}
+          <div className={cn("absolute w-0 h-0 border-4", arrowClasses[position])} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
Resolves #216. Added tooltips to the dashboard filter icons across all dashboard views (Admin, Organizer, Participant, Mentor).