### PR TITLE
feat(ui): Add autofocus to 'Title' input on Create Event form

### DIFF
--- a/app/(dashboard)/organizer/events/create/page.tsx
+++ b/app/(dashboard)/organizer/events/create/page.tsx
@@ -164,6 +164,7 @@ export default function CreateEventPage() {
                                     value={formData.title}
                                     onChange={handleChange}
                                     required
+                                    autoFocus
                                     placeholder="e.g. AI Innovation Hackathon 2024"
                                     className="h-12 text-lg"
                                 />


### PR DESCRIPTION
Closes #260
- Added the \`autoFocus\` attribute to the 'Event Title' input field in \`app/(dashboard)/organizer/events/create/page.tsx\`.
- This ensures the input automatically receives focus when an organizer loads the page, removing an unnecessary click from the event creation flow.