### PR TITLE
feat(ui): Add autofocus to 'Email' input on Login page

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -114,6 +114,7 @@ export default function LoginPage() {
                   type="email"
                   name="email"
                   required
+                  autoFocus
                   value={formData.email}
                   onChange={handleChange}
                   disabled={status.loading}


### PR DESCRIPTION
Closes #262
- Added the \`autoFocus\` attribute to the Email input field on the \`/login\` page.
- Improves UX by allowing organizers to immediately start typing credentials upon page load.