### PR TITLE
Docs: Add Getting Started as a Contributor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ Returns backend server status.
    ```
 
 Visit: http://localhost:3000
+## Default Ports
+
+During local development, the project uses the following default ports:
+
+- **Frontend:** http://localhost:3000
+- **Backend API:** http://localhost:5000
+
+This distinction helps ensure frontend applications are configured to communicate with the correct backend service.
 ## API Base URL
 
 During local development, the backend API is accessible at:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,13 @@ Utility functions, database connection logic, and shared helpers
 ---
 
 ## 🤝 Contributing
+## Getting Started as a Contributor
+
+If you’re new to EventFlow, the steps below can help you get started smoothly.
+
+- Check the list of open issues in the repository
+- Start with issues labeled `documentation` or `good first issue`
+- Ask to be assigned to an issue before starting work to avoid duplication
 
 1. Browse issues
 2. Get assigned by maintainer


### PR DESCRIPTION
## Summary
Adds a "Getting Started as a Contributor" section to the README to guide new contributors on how to begin contributing to the project.

## Problem
New contributors may be unsure about:
- How to find suitable issues
- Which issues to start with
- Whether assignment is required before starting work

This can lead to confusion, duplicate work, or hesitation in contributing.

## Proposed Change
Add a new section titled "Getting Started as a Contributor" with guidance to:
- Check open issues
- Start with `documentation` or `good first issue`
- Ask for assignment before starting work

## Why This Is Needed
- Improves onboarding experience
- Reduces duplicate contributions
- Encourages structured collaboration
- Makes the contribution workflow clearer

