### PR TITLE
Docs: Clarify that screenshots may not reflect latest UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ Returns backend server status.
    ```
 
 Visit: http://localhost:3000
+## Default Ports
+
+During local development, the project uses the following default ports:
+
+- **Frontend:** http://localhost:3000
+- **Backend API:** http://localhost:5000
+
+This distinction helps ensure frontend applications are configured to communicate with the correct backend service.
 ## API Base URL
 
 During local development, the backend API is accessible at:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ EventFlow addresses these challenges by providing a reusable, modular event infr
 
 ## 🖼️ Screenshots
 
- Note: The UI has been updated to a modern **Dark Sci-Fi Theme** with Aurora backgrounds.
+Note: The UI has been updated to a modern **Dark Sci-Fi Theme** with Aurora backgrounds.
+
+> Note: Screenshots may not reflect the latest UI during active development.
+
 <img width="1500" alt="EventFlow Sci-Fi UI" src="https://github.com/user-attachments/assets/184cae65-9946-498c-bc8d-36e975db0193" />
 <!-- TODO: Update with new Sci-Fi Theme Screenshot -->
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,13 @@ Utility functions, database connection logic, and shared helpers
 ---
 
 ## 🤝 Contributing
+## Getting Started as a Contributor
+
+If you’re new to EventFlow, the steps below can help you get started smoothly.
+
+- Check the list of open issues in the repository
+- Start with issues labeled `documentation` or `good first issue`
+- Ask to be assigned to an issue before starting work to avoid duplication
 
 1. Browse issues
 2. Get assigned by maintainer


### PR DESCRIPTION
## Summary
Adds a note to the README clarifying that screenshots may not reflect the latest UI during active development.

## Problem
New contributors and users may assume the screenshots always represent the current state of the application UI.

During active development, UI changes frequently, which can lead to confusion or incorrect expectations.

## Proposed Change
Add a short note under the Screenshots section:

> Note: Screenshots may not reflect the latest UI during active development.

## Why This Is Needed
- Sets correct expectations for contributors and users
- Prevents confusion when UI differs from screenshots
- Improves documentation clarity with minimal change

